### PR TITLE
fix: test shell completions without alias

### DIFF
--- a/scripts/test-zsh-completions
+++ b/scripts/test-zsh-completions
@@ -3,7 +3,7 @@
 # Any modification will disappear once you close the terminal tab
 
 mkdir -p tmp/completions/zsh
-snakepipe generate-completions --shell zsh > tmp/completions/zsh/_snakepipe
+./target/debug/snakepipe generate-completions --shell zsh > tmp/completions/zsh/_snakepipe
 fpath=("$PWD/tmp/completions/zsh" $fpath)
 autoload compinit
 compinit -i


### PR DESCRIPTION
On my `~/.zshrc`, I have a line like this:

```sh
export PATH="/Users/tophe/projects/snake-pipe-rust/target/debug:$PATH"
```

Which lets me use the debug version of `snakepipe` directly, without having to explicitly using `./target/debug/snakepipe`.

As a contributor, it shouldn't be mandatory to change any of your global configuration files to develop on this project.

This PR fixes the `scripts/test-zsh-completions` which refers directly to `snakepipe` when it should refer to `./target/debug/snakepipe` - everything else is already taken care of.